### PR TITLE
Add unit tests for org.dromara.soul.common.utils.UUIDUtils

### DIFF
--- a/soul-common/pom.xml
+++ b/soul-common/pom.xml
@@ -43,6 +43,34 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.6.6</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.6.6</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 

--- a/soul-common/src/test/java/org/dromara/soul/common/utils/UUIDUtilsTest.java
+++ b/soul-common/src/test/java/org/dromara/soul/common/utils/UUIDUtilsTest.java
@@ -1,0 +1,95 @@
+package org.dromara.soul.common.utils;
+
+import static org.mockito.Matchers.anyInt;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+import org.dromara.soul.common.utils.UUIDUtils;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Random;
+
+@RunWith(PowerMockRunner.class)
+public class UUIDUtilsTest {
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @PrepareForTest({Random.class, UUIDUtils.class, System.class})
+  @Test
+  public void testGenerateShortUuid() throws Exception {
+    PowerMockito.mockStatic(System.class);
+
+    final Random random = PowerMockito.mock(Random.class);
+    PowerMockito.when(random.nextInt(anyInt())).thenReturn(13).thenReturn(30);
+    PowerMockito.whenNew(Random.class).withNoArguments().thenReturn(random);
+    PowerMockito.when(System.currentTimeMillis()).thenReturn(1_515_585_600_000L).thenReturn(-1L);
+
+    Assert.assertEquals("951061054882631680", UUIDUtils.generateShortUuid());
+    Assert.assertEquals("-5405765689543892943", UUIDUtils.generateShortUuid());
+  }
+
+  @PrepareForTest({Random.class, UUIDUtils.class, System.class})
+  @Test
+  public void testGenerateShortUuidClockMovedBackwardsException() throws Exception {
+    PowerMockito.mockStatic(System.class);
+
+    final Random random = PowerMockito.mock(Random.class);
+    PowerMockito.when(random.nextInt(anyInt())).thenReturn(13);
+    PowerMockito.whenNew(Random.class).withNoArguments().thenReturn(random);
+    PowerMockito.when(System.currentTimeMillis()).thenReturn(-2L);
+
+    thrown.expect(RuntimeException.class);
+    UUIDUtils.generateShortUuid();
+  }
+
+  @PrepareForTest({Random.class, UUIDUtils.class})
+  @Test
+  public void testWorkerIdTooLarge() throws Exception {
+    final Random random = PowerMockito.mock(Random.class);
+    PowerMockito.when(random.nextInt(anyInt())).thenReturn(32);
+    PowerMockito.whenNew(Random.class).withNoArguments().thenReturn(random);
+
+    thrown.expect(IllegalArgumentException.class);
+    UUIDUtils.generateShortUuid();
+  }
+
+  @PrepareForTest({Random.class, UUIDUtils.class})
+  @Test
+  public void testWorkerIdTooSmall() throws Exception {
+    final Random random = PowerMockito.mock(Random.class);
+    PowerMockito.when(random.nextInt(anyInt())).thenReturn(-1);
+    PowerMockito.whenNew(Random.class).withNoArguments().thenReturn(random);
+
+    thrown.expect(IllegalArgumentException.class);
+    UUIDUtils.generateShortUuid();
+  }
+
+  @PrepareForTest({Random.class, UUIDUtils.class})
+  @Test
+  public void testDatacenterIdTooLarge() throws Exception {
+    final Random random = PowerMockito.mock(Random.class);
+    PowerMockito.when(random.nextInt(anyInt())).thenReturn(13).thenReturn(32);
+    PowerMockito.whenNew(Random.class).withNoArguments().thenReturn(random);
+
+    thrown.expect(IllegalArgumentException.class);
+    UUIDUtils.generateShortUuid();
+  }
+
+  @PrepareForTest({Random.class, UUIDUtils.class})
+  @Test
+  public void testDatacenterIdTooSmall() throws Exception {
+    final Random random = PowerMockito.mock(Random.class);
+    PowerMockito.when(random.nextInt(anyInt())).thenReturn(13).thenReturn(-1);
+    PowerMockito.whenNew(Random.class).withNoArguments().thenReturn(random);
+
+    thrown.expect(IllegalArgumentException.class);
+    UUIDUtils.generateShortUuid();
+  }
+}


### PR DESCRIPTION
Hi,

I've analysed your code base and noticed that `org.dromara.soul.common.utils.UUIDUtils` in the `soul-common` module is not fully tested.

I've written some tests for the functions in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

In addition, I noticed that instantiating UUIDUtils via the public constructor will never cause the block at line 83 to be entered. 

Hopefully these tests should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other particular classes that you consider important.